### PR TITLE
Fix pseudo block replacements

### DIFF
--- a/src/Autoprefixer.php
+++ b/src/Autoprefixer.php
@@ -47,9 +47,14 @@ class Autoprefixer {
             }
 
             // DeclarationBlock
-            if($content instanceof \Sabberworm\CSS\RuleSet\DeclarationBlock){
-                $compile_declarationBlock = new Compile\DeclarationBlock($content);
-                $compile_declarationBlock->compile();
+            if ($content instanceof \Sabberworm\CSS\RuleSet\DeclarationBlock){
+                 $compile_declarationBlock = new Compile\DeclarationBlock($content);
+                 $m_declarationBlock = $compile_declarationBlock->compile();
+
+                 if ($m_declarationBlock){
+                      // Pseudo selctors must have their own Declaration Block
+                      $vendor_contents = array_merge($vendor_contents, $m_declarationBlock);
+                 }
             }
 
             // AtRule

--- a/src/Compile/DeclarationBlock.php
+++ b/src/Compile/DeclarationBlock.php
@@ -41,6 +41,18 @@ class DeclarationBlock {
             }
         }
         
+        if ($total_added){
+             $vendor_contents = [];
+
+             foreach ($vendors_selector as $key => $selector){
+                  $p_declarationBlock = clone $this->declarationBlock;
+                  $p_declarationBlock->setSelectors($selector->getSelector());
+                  $vendor_contents[] = $p_declarationBlock;
+             }
+
+             return $vendor_contents;
+        }
+
         $this->declarationBlock->setSelectors($m_selectors);
     }
 }


### PR DESCRIPTION
Hi, did a pr for issue (part of) #17 
what this pr does is add a separate Declaration Block per vendor pseudo code as having the different vendor's pseudo codes on one (1) Declaration Block is not valid / recognized / handled correctly by browsers.

css code
```
.form-control::placeholder {
	color: #6c757d;
	opacity: 1;
}
```
### before this patch:
```
.form-control::-ms-input-placeholder, .form-control::-moz-placeholder, .form-control::-webkit-input-placeholder, .form-control::placeholder {
        color: #6c757d;
        opacity: 1;
}
```
### after this patch
```
.form-control::-ms-input-placeholder {
        color: #6c757d;
        opacity: 1;
}

.form-control::-moz-placeholder {
        color: #6c757d;
        opacity: 1;
}

.form-control::-webkit-input-placeholder {
        color: #6c757d;
        opacity: 1;
}

.form-control::placeholder {
        color: #6c757d;
        opacity: 1;
}
```
cc: @kubiqsk