### PR TITLE
Add option to pass browser vendors

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ composer require padaliyajay/php-autoprefixer
 Although it's recommended to use Composer, you can actually [include these files](https://github.com/padaliyajay/php-autoprefixer/wiki/Installation) anyway you want.
 
 ## Usage
-```
+```php
 use Padaliyajay\PHPAutoprefixer\Autoprefixer;
 
 $unprefixed_css = file_get_contents('main.css'); // CSS code
@@ -17,6 +17,37 @@ $unprefixed_css = file_get_contents('main.css'); // CSS code
 $autoprefixer = new Autoprefixer($unprefixed_css);
 $prefixed_css = $autoprefixer->compile();
 ```
+
+## Options
+
+You can pass options to the `compile()` method.
+
+### `prettyOutput`
+
+Example:
+```php
+$autoprefixer->compile(false); // Output minified CSS
+```
+Defines if the prefixed CSS will be a verbose/prettified output. When `false` the output will be minified.
+
+Default: `true`
+
+### `vendors`
+
+Example:
+```php
+$custom_vendors = array(
+    // Padaliyajay\PHPAutoprefixer\Vendor\IE::class, // Omit prefixes for IE
+    Padaliyajay\PHPAutoprefixer\Vendor\Webkit::class,
+    Padaliyajay\PHPAutoprefixer\Vendor\Mozilla::class,
+    MyNamespace\Custom\Opera::class // Use custom vendor prefixes
+);
+
+$autoprefixer->compile(false, $custom_vendors);
+```
+Define which vendor classes should be used for prefixing. You can omit unwanted vendors like e.g. IE. If passed, only the vendor classes in the array will be used.
+
+Default: `null`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Default: `true`
 Example:
 ```php
 $custom_vendors = array(
-    // Padaliyajay\PHPAutoprefixer\Vendor\IE::class, // Omit prefixes for IE
+    // Omit prefixes for IE
     Padaliyajay\PHPAutoprefixer\Vendor\Webkit::class,
     Padaliyajay\PHPAutoprefixer\Vendor\Mozilla::class,
     MyNamespace\Custom\Opera::class // Use custom vendor prefixes
@@ -45,9 +45,16 @@ $custom_vendors = array(
 
 $autoprefixer->compile(false, $custom_vendors);
 ```
-Define which vendor classes should be used for prefixing. You can omit unwanted vendors like e.g. IE. If passed, only the vendor classes in the array will be used.
+Define which vendor classes should be used for prefixing. You can omit unwanted vendors like e.g. IE. If passed, only the vendor classes in the passed array will be used.
 
-Default: `null`
+Default: 
+```php
+array(
+    Padaliyajay\PHPAutoprefixer\Vendor\IE::class,
+    Padaliyajay\PHPAutoprefixer\Vendor\Webkit::class,
+    Padaliyajay\PHPAutoprefixer\Vendor\Mozilla::class,
+)
+```
 
 ## License
 

--- a/src/Autoprefixer.php
+++ b/src/Autoprefixer.php
@@ -20,7 +20,7 @@ class Autoprefixer {
             return false;
         }
 
-        if ($vendors && is_array($vendors)) {
+        if (is_array($vendors)) {
             Vendor::setVendors($vendors);
         }
 

--- a/src/Autoprefixer.php
+++ b/src/Autoprefixer.php
@@ -11,22 +11,28 @@ class Autoprefixer {
 
     /**
      * @param bool $prettyOutput
+     * @param null|array $vendors
      * @return string|false
+     * @throws \Sabberworm\CSS\Parsing\SourceException
      */
-    public function compile($prettyOutput = true) {
-        if($this->css_parser){
-            $css_document = $this->css_parser->parse();
-
-            $this->compileCSSList($css_document);
-
-            $outputFormat = $prettyOutput ?
-                \Sabberworm\CSS\OutputFormat::createPretty() :
-                \Sabberworm\CSS\OutputFormat::createCompact();
-
-            return $css_document->render($outputFormat);
-        } else {
+    public function compile($prettyOutput = true, $vendors = null) {
+        if (!$this->css_parser) {
             return false;
         }
+
+        if ($vendors && is_array($vendors)) {
+            Vendor::setVendors($vendors);
+        }
+
+        $css_document = $this->css_parser->parse();
+
+        $this->compileCSSList($css_document);
+
+        $outputFormat = $prettyOutput ?
+            \Sabberworm\CSS\OutputFormat::createPretty() :
+            \Sabberworm\CSS\OutputFormat::createCompact();
+
+        return $css_document->render($outputFormat);
     }
 
     /**

--- a/src/Vendor.php
+++ b/src/Vendor.php
@@ -1,31 +1,38 @@
 <?php
 namespace Padaliyajay\PHPAutoprefixer;
 
+use Padaliyajay\PHPAutoprefixer\Vendor\IE;
+use Padaliyajay\PHPAutoprefixer\Vendor\Mozilla;
+use Padaliyajay\PHPAutoprefixer\Vendor\Webkit;
+
 class Vendor {
-    const Vendors = array('IE', 'Mozilla', 'Webkit');
-    
+    public static $vendors = array(
+        IE::class,
+        Mozilla::class,
+        Webkit::class
+    );
+
     public static function getRuleProperty($vendor){
-        $vendor_class = 'Padaliyajay\PHPAutoprefixer\Vendor\\' . $vendor;
-        return $vendor_class::getRuleProperty();
+        return $vendor::getRuleProperty();
     }
-    
+
     public static function getRuleValue($vendor){
-        $vendor_class = 'Padaliyajay\PHPAutoprefixer\Vendor\\' . $vendor;
-        return $vendor_class::getRuleValue();
+        return $vendor::getRuleValue();
     }
-    
+
     public static function getPseudo($vendor){
-        $vendor_class = 'Padaliyajay\PHPAutoprefixer\Vendor\\' . $vendor;
-        return $vendor_class::getPseudo();
+        return $vendor::getPseudo();
     }
-    
+
     public static function getATRule($vendor){
-        $vendor_class = 'Padaliyajay\PHPAutoprefixer\Vendor\\' . $vendor;
-        return $vendor_class::getATRule();
+        return $vendor::getATRule();
     }
-    
+
     public static function getVendors(){
-        return self::Vendors;
+        return self::$vendors;
+    }
+
+    public static function setVendors($vendors){
+        self::$vendors = $vendors;
     }
 }
-

--- a/test/test.php
+++ b/test/test.php
@@ -1,5 +1,5 @@
 <?php
-require_once 'vendor/autoload.php';
+require_once '../vendor/autoload.php';
 
 use Padaliyajay\PHPAutoprefixer\Autoprefixer;
 

--- a/test/test.php
+++ b/test/test.php
@@ -1,5 +1,5 @@
 <?php
-require_once '../vendor/autoload.php';
+require_once 'vendor/autoload.php';
 
 use Padaliyajay\PHPAutoprefixer\Autoprefixer;
 


### PR DESCRIPTION
Hi 👋 

currently the browser vendors seem to be hard-coded inside the /Vendor/ classes. For some projects e.g. the IE prefixes will no longer be needed. Bootstrap v5 has also removed those prefixes in their compiled version.

* This PR adds the possibility to override the vendors currently hard-coded inside Vendor `const Vendors = array('IE', 'Mozilla', 'Webkit');` https://github.com/padaliyajay/php-autoprefixer/blob/master/src/Vendor.php#L5
* Instead of using a string it uses the class name directly, so theoretically one could also add custom vendor classes without editing the composer/vendor files directly.

```php 
$custom_vendors = array(
    // Omit prefixes for IE
    Padaliyajay\PHPAutoprefixer\Vendor\Webkit::class,
    Padaliyajay\PHPAutoprefixer\Vendor\Mozilla::class,
    MyNamespace\Custom\Opera::class // Use custom vendor prefixes
);

$autoprefixer->compile(false, $custom_vendors);
```