### PR TITLE
Fix: sabberworm removed __toString, replacing usage with advised repl…

### DIFF
--- a/src/Autoprefixer.php
+++ b/src/Autoprefixer.php
@@ -79,7 +79,14 @@ class Autoprefixer {
 
             // Remove already existing vendor content
             $vendor_contents = array_filter($vendor_contents, function($vendor_content) use($m_contents){
-                if(!in_array((string)$vendor_content, array_map('strval', $m_contents))){
+                $outputFormat = new \Sabberworm\CSS\OutputFormat();
+                $current_vendor_string = $vendor_content->render($outputFormat);
+                
+                $m_contents_strings = array_map(function ($m_content_obj) use ($outputFormat) {
+                    return $m_content_obj->render($outputFormat);
+                }, $m_contents);
+
+                if(!in_array($current_vendor_string, $m_contents_strings)){
                     return true;
                 } else {
                     return false;

--- a/src/Compile/DeclarationBlock.php
+++ b/src/Compile/DeclarationBlock.php
@@ -30,13 +30,21 @@ class DeclarationBlock {
             
             // Remove already existing value
             $_vendors_selector = array_merge($_vendors_selector, array_filter($vendors_selector, function ($vendor_selector) use ($m_selectors) {
-                if(!in_array((string)$vendor_selector, array_map('strval', $m_selectors))){
+                $outputFormat = new \Sabberworm\CSS\OutputFormat();
+                $current_vendor_string = $vendor_selector->render($outputFormat);
+        
+                $m_selectors_strings = array_map(function ($m_selector_obj) use ($outputFormat) {
+                    // Use the new render method on each individual object
+                    return $m_selector_obj->render($outputFormat);
+                }, $m_selectors);
+
+                if(!in_array($current_vendor_string, $m_selectors_strings)){
                     return true;
                 } else {
                     return false;
                 }
             }));
-            
+
             if($_vendors_selector){
                 array_splice($m_selectors, $key + $total_added, 0, $vendors_selector);
                 $total_added += count($_vendors_selector);

--- a/src/Compile/RuleSet.php
+++ b/src/Compile/RuleSet.php
@@ -28,7 +28,14 @@ class RuleSet {
             
             // Remove already existing value
             $vendor_rules = array_filter($vendor_rules, function($vendor_rule) use($m_rules) {
-                if(!in_array((string)$vendor_rule, array_map('strval', $m_rules))){
+                $outputFormat = new \Sabberworm\CSS\OutputFormat();
+                $current_vendor_string = $vendor_rule->render($outputFormat);
+                
+                $m_rules_strings = array_map(function ($m_rule_obj) use ($outputFormat) {
+                    return $m_rule_obj->render($outputFormat);
+                }, $m_rules);
+
+                if(!in_array($current_vendor_string, $m_rules_strings)){
                     return true;
                 } else {
                     return false;

--- a/src/Parse/Rule.php
+++ b/src/Parse/Rule.php
@@ -33,7 +33,7 @@ class Rule {
             
             if($rule_vendor_property){
                 $vendor_rule = clone $this->rule;
-                $vendor_rule->setRule((string)$rule_vendor_property);
+                $vendor_rule->setRule($rule_vendor_property->render(new \Sabberworm\CSS\OutputFormat()));
                 
                 $vendor_value = $rule_vendor_property->getVendorValue($this->rule->getValue(), $vendor);
                 if($vendor_value){


### PR DESCRIPTION
…acements

Hi,
Sabberworm has deprecated it's __toString() function on Selector and Ruleset in version 8.8.0, it has been removed in version 9.0.0

    /**
     * @return string
     *
     * @deprecated in V8.8.0, will be removed in V9.0.0. Use `render` instead.
     */
    public function __toString()

https://github.com/MyIntervals/PHP-CSS-Parser/commit/c9d37e7e098f256563ccc644c0535e9f1406c6ef

This now leads into an error with this repository as it does type casting to (string) which doesn't work anymore.

This PR replaces the relevant string type casting with the proposed render() function.

Hope this helps!


