### PR TITLE
#31 - Revert part of https://github.com/padaliyajay/php-autoprefixer/pull/30

### DIFF
--- a/src/Parse/Rule.php
+++ b/src/Parse/Rule.php
@@ -33,7 +33,7 @@ class Rule {
             
             if($rule_vendor_property){
                 $vendor_rule = clone $this->rule;
-                $vendor_rule->setRule($rule_vendor_property->render(new \Sabberworm\CSS\OutputFormat()));
+                $vendor_rule->setRule((string)$rule_vendor_property);
                 
                 $vendor_value = $rule_vendor_property->getVendorValue($this->rule->getValue(), $vendor);
                 if($vendor_value){


### PR DESCRIPTION
`$rule_vendor_property` in rule.php isn't an object from sabberworm and is an instance of `Padaliyajay\PHPAutoprefixer\Parse\Property` which works fine still with a `(string)` cast. The PR https://github.com/padaliyajay/php-autoprefixer/pull/30 was about removing string casts for sabberworm objects.

This PR fixes the error in #31 for me.